### PR TITLE
Set importlib metadata version

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,11 +4,15 @@ bump2version==0.5.11
 wheel==0.33.6
 watchdog==0.9.0
 flake8==3.7.8
-tox==4.8.0
 coverage==4.5.4
 Sphinx==1.8.5
+
+# Version-specific dependencies
+tox==3.24.0; python_version < '3.8'
+tox==4.8.0; python_version >= '3.8'
+importlib_metadata<5.0.0; python_version < '3.8'
+importlib_metadata==7.2.1; python_version >= '3.8'
 twine==4.0.2
-importlib_metadata==7.2.1  # Pin specific version for twine compatibility https://github.com/astral-sh/rye/issues/1180
 
 pytest==7.4.3
 pytest-runner==5.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,6 +8,7 @@ tox==4.8.0
 coverage==4.5.4
 Sphinx==1.8.5
 twine==4.0.2
+importlib_metadata==7.2.1  # Pin specific version for twine compatibility https://github.com/astral-sh/rye/issues/1180
 
 pytest==7.4.3
 pytest-runner==5.1


### PR DESCRIPTION
Set the importlib metadata version to a version that is compatible with Twine v4.
GitHub issue explaining the issue, https://github.com/astral-sh/rye/issues/1180
