### PR TITLE
Not all send code samples change for the eu region

### DIFF
--- a/notificationapi_python_server_sdk/__init__.py
+++ b/notificationapi_python_server_sdk/__init__.py
@@ -3,3 +3,8 @@
 __author__ = """Sahand Seifi"""
 __email__ = "sahand.seifi@gmail.com"
 __version__ = "1.2.0"
+
+# Region constants
+US_REGION = "https://api.notificationapi.com"
+EU_REGION = "https://api.eu.notificationapi.com"
+CA_REGION = "https://api.ca.notificationapi.com"

--- a/notificationapi_python_server_sdk/__init__.py
+++ b/notificationapi_python_server_sdk/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Sahand Seifi"""
 __email__ = "sahand.seifi@gmail.com"
-__version__ = "1.2.0"
+__version__ = "1.3.0"
 
 # Region constants
 US_REGION = "https://api.notificationapi.com"

--- a/notificationapi_python_server_sdk/__init__.py
+++ b/notificationapi_python_server_sdk/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Sahand Seifi"""
 __email__ = "sahand.seifi@gmail.com"
-__version__ = "1.3.0"
+__version__ = "2.0.0"
 
 # Region constants
 US_REGION = "https://api.notificationapi.com"

--- a/notificationapi_python_server_sdk/notificationapi.py
+++ b/notificationapi_python_server_sdk/notificationapi.py
@@ -3,12 +3,14 @@ import logging
 import hashlib
 import base64
 import urllib.parse
+from . import US_REGION
 
 __client_id = ""
 __client_secret = ""
+__base_url = US_REGION
 
 
-def init(client_id, client_secret):
+def init(client_id, client_secret, base_url=None):
     if not client_id:
         raise Exception("Bad client_id")
 
@@ -19,10 +21,15 @@ def init(client_id, client_secret):
     __client_id = client_id
     global __client_secret
     __client_secret = client_secret
-
+    
+    global __base_url
+    if base_url:
+        __base_url = base_url
+    else:
+        __base_url = US_REGION
 
 async def request(method, uri, data=None, custom_auth=None, queryStrings=None):
-    api_url = "https://api.notificationapi.com/" + __client_id + "/" + uri
+    api_url = f"{__base_url}/{__client_id}/{uri}"
 
     headers = {}
     if custom_auth:
@@ -46,6 +53,8 @@ async def request(method, uri, data=None, custom_auth=None, queryStrings=None):
             response.text,
             data,
         )
+    
+    return response
 
 
 async def send(params):

--- a/notificationapi_python_server_sdk/notificationapi.py
+++ b/notificationapi_python_server_sdk/notificationapi.py
@@ -21,12 +21,12 @@ def init(client_id, client_secret, base_url=None):
     __client_id = client_id
     global __client_secret
     __client_secret = client_secret
-    
     global __base_url
     if base_url:
         __base_url = base_url
     else:
         __base_url = US_REGION
+
 
 async def request(method, uri, data=None, custom_auth=None, queryStrings=None):
     api_url = f"{__base_url}/{__client_id}/{uri}"
@@ -53,7 +53,6 @@ async def request(method, uri, data=None, custom_auth=None, queryStrings=None):
             response.text,
             data,
         )
-    
     return response
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.3.0
+current_version = 2.0.0
 commit = True
 tag = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.2.0
+current_version = 1.3.0
 commit = True
 tag = True
 
@@ -23,4 +23,3 @@ test = pytest
 
 [tool:pytest]
 collect_ignore = ['setup.py']
-

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/notificationapi-com/notificationapi_python_server_sdk",
-    version="1.2.0",
+    version="1.3.0",
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/notificationapi-com/notificationapi_python_server_sdk",
-    version="1.3.0",
+    version="2.0.0",
     zip_safe=False,
 )

--- a/tests/test_notificationapi_regions.py
+++ b/tests/test_notificationapi_regions.py
@@ -25,14 +25,15 @@ def test_init_with_ca_region():
     notificationapi.init(client_id, client_secret, CA_REGION)
     assert notificationapi.__base_url == CA_REGION
 
+
 @pytest.mark.asyncio
 async def test_request_uses_correct_region_url(respx_mock):
     # Test with EU region
     eu_api_url = f"{EU_REGION}/{client_id}/sender"
     route = respx_mock.post(eu_api_url).mock(return_value=httpx.Response(200))
-    
+
     notificationapi.init(client_id, client_secret, EU_REGION)
     await notificationapi.send({"notificationId": "test", "user": {"id": "user1"}})
-    
+
     assert route.called
     assert route.calls.last.request.url == eu_api_url

--- a/tests/test_notificationapi_regions.py
+++ b/tests/test_notificationapi_regions.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+
+"""Tests for region support in `notificationapi_python_server_sdk` package."""
+
+import pytest
+import httpx
+from notificationapi_python_server_sdk import notificationapi, US_REGION, EU_REGION, CA_REGION
+
+client_id = "client_id"
+client_secret = "client_secret"
+
+
+def test_init_with_default_region():
+    notificationapi.init(client_id, client_secret)
+    # Access the private variable directly - it's defined at module level
+    assert notificationapi.__base_url == US_REGION
+
+
+def test_init_with_eu_region():
+    notificationapi.init(client_id, client_secret, EU_REGION)
+    assert notificationapi.__base_url == EU_REGION
+
+
+def test_init_with_ca_region():
+    notificationapi.init(client_id, client_secret, CA_REGION)
+    assert notificationapi.__base_url == CA_REGION
+
+
+def test_init_with_custom_url():
+    custom_url = "https://custom-api.example.com"
+    notificationapi.init(client_id, client_secret, custom_url)
+    assert notificationapi.__base_url == custom_url
+
+
+@pytest.mark.asyncio
+async def test_request_uses_correct_region_url(respx_mock):
+    # Test with EU region
+    eu_api_url = f"{EU_REGION}/{client_id}/sender"
+    route = respx_mock.post(eu_api_url).mock(return_value=httpx.Response(200))
+    
+    notificationapi.init(client_id, client_secret, EU_REGION)
+    await notificationapi.send({"notificationId": "test", "user": {"id": "user1"}})
+    
+    assert route.called
+    assert route.calls.last.request.url == eu_api_url

--- a/tests/test_notificationapi_regions.py
+++ b/tests/test_notificationapi_regions.py
@@ -25,13 +25,6 @@ def test_init_with_ca_region():
     notificationapi.init(client_id, client_secret, CA_REGION)
     assert notificationapi.__base_url == CA_REGION
 
-
-def test_init_with_custom_url():
-    custom_url = "https://custom-api.example.com"
-    notificationapi.init(client_id, client_secret, custom_url)
-    assert notificationapi.__base_url == custom_url
-
-
 @pytest.mark.asyncio
 async def test_request_uses_correct_region_url(respx_mock):
     # Test with EU region

--- a/tests/test_notificationapi_send.py
+++ b/tests/test_notificationapi_send.py
@@ -5,7 +5,7 @@
 import pytest
 import json
 from httpx import Response
-from notificationapi_python_server_sdk import notificationapi
+from notificationapi_python_server_sdk import notificationapi, US_REGION
 
 client_id = "client_id"
 client_secret = "client_secret"
@@ -17,7 +17,7 @@ user = {
 userId = "userId"
 notification_id = "notification_id"
 api_paths = {
-    "send": f"https://api.notificationapi.com/{client_id}/sender",
+    "send": f"{US_REGION}/{client_id}/sender",
 }
 
 


### PR DESCRIPTION
- Add optional base URL parameter to the SDK initialization
- Set base URL to the US by default
- Add region constants to easily and reliably set the region base URLs
- Add tests to ensure the correct endpoints are being set for each region